### PR TITLE
Dockerfile: Use openjdk base image instead of java

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # DSpace image
 #
 
-FROM java:openjdk-7u95
+FROM openjdk:7-jdk
 MAINTAINER 1science Devops Team <devops@1science.org>
 
 # Environment variables


### PR DESCRIPTION
The [java base image is deprecated](https://hub.docker.com/_/java/), so we need to use the [openjdk image](https://hub.docker.com/_/openjdk/). Also, this changes the effective JDK version to the latest stable release (using the `jdk-7` tag this is currently version 1.7.0_111).

Tested and working with DSpace 5.6 locally, based on this Dockerfile.